### PR TITLE
Add Flux models in the .dockerignore, to exclude them from being pushed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,4 @@ __pycache__
 /venv
 
 # Exclude the Flux schnell or dev models from being pushed
-FLUX.1?
+FLUX.1*

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,6 @@ __pycache__
 
 # Exclude Python virtual environment
 /venv
+
+# Exclude the Flux schnell or dev models from being pushed
+FLUX.1?


### PR DESCRIPTION
Noticed the cog pushing was taking a long time, adding the models to .dockerignore file seems to have fixed it (thanks for tip Sakib)